### PR TITLE
Update Dockerfile base and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,9 @@ This add-on scans your Home Assistant server and ecosystem for security vulnerab
 🌐 Web-based interface with multilingual support (🇬🇧 English / 🇳🇱 Dutch)
 Use the language selector at the top of the dashboard to switch translations
 📝 Per-module logs + downloadable full report
+
+## Build Process
+
+The add-on's Dockerfile now uses the lightweight `python:3.11-alpine` image.
+Python and `pip` are included, so only `bash` needs to be installed. Building
+is as simple as running a standard `docker build` command.

--- a/security_suite/Dockerfile
+++ b/security_suite/Dockerfile
@@ -1,19 +1,12 @@
-ARG BUILD_FROM
-FROM $BUILD_FROM
+FROM python:3.11-alpine
 
 ENV LANG C.UTF-8
 
-# Installeer OS-pakketten
-RUN apk add --no-cache \
-    python3 \
-    py3-pip \
-    bash
-
-# Zorg dat pip3 werkt
-RUN python3 -m ensurepip && pip3 install --no-cache-dir --upgrade pip setuptools wheel
+# Install only required packages
+RUN apk add --no-cache bash
 
 # Installeer Flask
-RUN pip3 install flask
+RUN pip install flask
 
 # Bestanden toevoegen
 COPY run.sh /run.sh


### PR DESCRIPTION
## Summary
- use python:3.11-alpine as Dockerfile base image
- install only bash in the container
- keep `pip install flask` step
- document simplified build process in README

## Testing
- `python3 -m py_compile security_suite/webserver.py`

------
https://chatgpt.com/codex/tasks/task_e_685709921f308330885542f38e138505