### PR TITLE
Update Dockerfile to use /app workdir

### DIFF
--- a/security_suite/Dockerfile
+++ b/security_suite/Dockerfile
@@ -9,11 +9,14 @@ RUN apk add --no-cache bash
 COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
+# Set workdir
+WORKDIR /app
+
 # Bestanden toevoegen
-COPY run.sh /run.sh
-COPY webserver.py /webserver.py
-COPY templates/ /templates/
+COPY run.sh /app/run.sh
+COPY webserver.py /app/webserver.py
+COPY templates/ /app/templates/
 
-RUN chmod +x /run.sh
+RUN chmod +x /app/run.sh
 
-CMD [ "/run.sh" ]
+CMD [ "/app/run.sh" ]

--- a/security_suite/run.sh
+++ b/security_suite/run.sh
@@ -2,4 +2,4 @@
 
 
 echo "[INFO] Starten van Security Suite GUI..."
-python3 /webserver.py
+python3 /app/webserver.py


### PR DESCRIPTION
## Summary
- set `WORKDIR /app`
- copy scripts into `/app`
- run `/app/run.sh`
- update run script for new path

## Testing
- `python3 -m py_compile security_suite/webserver.py`
- `bash -n security_suite/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68570ea868288330ace6db5b83054506