### PR TITLE
Update Flask version in requirements

### DIFF
--- a/security_suite/requirements.txt
+++ b/security_suite/requirements.txt
@@ -1,1 +1,1 @@
-Flask==<desired-version>
+Flask==2.3.2


### PR DESCRIPTION
## Summary
- pin Flask dependency to `2.3.2`

## Testing
- `docker build -t security_suite_test security_suite` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68570fb333708330b0ac43e86a345499